### PR TITLE
Change cookie name value

### DIFF
--- a/app/components/CookieBanner.tsx
+++ b/app/components/CookieBanner.tsx
@@ -11,17 +11,17 @@ export const CookieBanner = () => {
   const path = usePathname()
 
   useEffect(() => {
-    const cookieConsent = Cookies.get('cookie_consent')
+    const cookieConsent = Cookies.get('etherlink_cookie_consent')
     setIsVisible(!cookieConsent)
   }, [])
 
   const handleAccept = () => {
-    Cookies.set('cookie_consent', 'accepted', { expires: 365 })
+    Cookies.set('etherlink_cookie_consent', 'accepted', { expires: 365 })
     setIsVisible(false)
   }
 
   const handleNecessaryOnly = () => {
-    Cookies.set('cookie_consent', 'necessary', { expires: 365 })
+    Cookies.set('etherlink_cookie_consent', 'necessary', { expires: 365 })
     setIsVisible(false)
   }
 


### PR DESCRIPTION
## Overview
 <!--- Description of the scope of the PR. Add details what has changed (and why if needed) --->
We want to have the same cookie consent for both etherlink home page and bridge page. This change is to make the naming more clear.
## Tickets
<!--- Paste Asana/Linear tickets here --->
Related [linear ticket](https://linear.app/tezos/issue/ETH-44/re-enable-ga-cookies-for-bridgeetherlinkcom)
## Notes for reviewer (optional)
<!--- 
- (For example): I wasn't sure whether to implement a caching strategy [here](https://…), so I left a comment and suggest that this is handled in a separate [ticket](https://…)
--->
