### PR TITLE
smeall amends for ecosystem page

### DIFF
--- a/app/ecosystem/Hero.tsx
+++ b/app/ecosystem/Hero.tsx
@@ -86,7 +86,8 @@ export const Hero = () => {
 
         <h1 className='text-[32px] md:text-[35px] text-start md:text-center font-bold mb-2'>
           {words.map((w, i) => (
-            <span key={w} className={`${i < words.length - 1 ? 'mr-2' : ''}`}>
+            <span key={w}>
+              {i === 1 && <span className='text-neonGreen-50'>,</span>}{' '}
               {i === 2 && <span className='text-neonGreen-50'>&amp;</span>}{' '}
               <span
                 className={`${

--- a/app/ecosystem/Search.tsx
+++ b/app/ecosystem/Search.tsx
@@ -19,7 +19,7 @@ type SearchProps = {
   setSelectedTags: Dispatch<SetStateAction<TagKeys[]>>
 }
 
-const TRENDING: TagKeys[] = ['defi', 'dev-tools', 'infra', 'gaming', 'payments']
+const TRENDING: TagKeys[] = ['defi', 'dev-tools', 'infra']
 
 export const Search = ({
   search,


### PR DESCRIPTION
## Overview
 <!--- Description of the scope of the PR. Add details what has changed (and why if needed) --->
- The header 'Discover Build & Trade on Etherlink' is missing a comma. It should be 'Discover, Build & Trade on Etherlink'
- Remove Gaming and Payments from trending searches? We only have 1 game and no payment dApps... so it looks bad.
## Tickets
<!--- Paste Asana/Linear tickets here --->

## Notes for reviewer (optional)
<!--- 
- (For example): I wasn't sure whether to implement a caching strategy [here](https://…), so I left a comment and suggest that this is handled in a separate [ticket](https://…)
--->
