### PR TITLE
Fix zindex issue on ecosystem buttons

### DIFF
--- a/app/ecosystem/FilterButton.tsx
+++ b/app/ecosystem/FilterButton.tsx
@@ -74,7 +74,7 @@ export const FilterButton = ({
   )
 
   return (
-    <div ref={ref} className='relative inline-block text-left z-30'>
+    <div ref={ref} className='relative inline-block text-left'>
       <button
         onClick={toggleOpen}
         className={`

--- a/app/ecosystem/SortButton.tsx
+++ b/app/ecosystem/SortButton.tsx
@@ -50,7 +50,7 @@ export const SortButton = ({ selected, onSelect }: SortButtonProps) => {
   }, [])
 
   return (
-    <div ref={ref} className='relative inline-block text-left z-30'>
+    <div ref={ref} className='relative inline-block text-left'>
       <button
         onClick={() => setIsOpen(v => !v)}
         className={`


### PR DESCRIPTION
## Overview
 <!--- Description of the scope of the PR. Add details what has changed (and why if needed) --->
Quick fix for zindex issue when open the mobile nav drawer
<img width="441" alt="Screenshot 2025-05-29 at 12 39 21" src="https://github.com/user-attachments/assets/8d81cad1-b4c7-49e0-bea4-dda90bf3d871" />

## Tickets
<!--- Paste Asana/Linear tickets here --->

## Notes for reviewer (optional)
<!--- 
- (For example): I wasn't sure whether to implement a caching strategy [here](https://…), so I left a comment and suggest that this is handled in a separate [ticket](https://…)
--->
