### PR TITLE
temp fix for trending tags bug on ecosystem page

### DIFF
--- a/app/ecosystem/ProjectList.tsx
+++ b/app/ecosystem/ProjectList.tsx
@@ -62,7 +62,7 @@ export const ProjectList = ({ projects }: { projects: Project[] }) => {
         searchActive &&
         (p.Project.toLowerCase().includes(term) ||
           p.Description.toLowerCase().includes(term) ||
-          p.Tags.some(t => TAGS_MAP[t].toLowerCase().includes(term)))
+          p.Tags.some(t => TAGS_MAP[t]?.toLowerCase().includes(term)))
       const matchesTags =
         tagsActive && p.Tags.some(t => selectedTags.includes(t))
 
@@ -89,7 +89,7 @@ export const ProjectList = ({ projects }: { projects: Project[] }) => {
       const matchesSearch = (p: Project) =>
         p.Project.toLowerCase().includes(term) ||
         p.Description.toLowerCase().includes(term) ||
-        p.Tags.some(t => TAGS_MAP[t].toLowerCase().includes(term))
+        p.Tags.some(t => TAGS_MAP[t]?.toLowerCase().includes(term))
 
       const searchMatches: Project[] = []
       const tagMatchesOnly: Project[] = []


### PR DESCRIPTION
## Overview
 <!--- Description of the scope of the PR. Add details what has changed (and why if needed) --->
This PR is to quickly fix clicking trending tags break the frontend. The issue comes from we defined projects' tags manually and some project's tags are not in the list.  Thus it has `Cannot read properties of undefined (reading 'toLowerCase')`
We have a ticket to pull tags from airtable rather than defined tags ourselves
## Tickets
<!--- Paste Asana/Linear tickets here --->

## Notes for reviewer (optional)
<!--- 
- (For example): I wasn't sure whether to implement a caching strategy [here](https://…), so I left a comment and suggest that this is handled in a separate [ticket](https://…)
--->
