### PR TITLE
ETH-141: fix scrape images from airtable

### DIFF
--- a/scrapeImagesAirTable.js
+++ b/scrapeImagesAirTable.js
@@ -6,7 +6,7 @@ const fetch = (...args) =>
 const buildOutFolder = './out'
 const mirrorFolderName = 'img-airtable'
 const graphAssetUrlRegex =
-  /https?:\/\/[^\"\'\s]+airtableusercontent.com[^\"\'\s]*/g
+  /https?:\/\/[^\s"'\\]+airtableusercontent\.com[^\s"'\\]*(?<![\/\\])/g
 
 const mirrorFolderPath = `${buildOutFolder}/${mirrorFolderName}`
 const filesToParse = ['html', 'js', 'json']


### PR DESCRIPTION
## Overview
 <!--- Description of the scope of the PR. Add details what has changed (and why if needed) --->
The airtable url having trailing /, so it fails to fetch images.
eg `04 - Not Found
Failed to fetch https://v5.airtableusercontent.com/v3/u/43/43/1753380000000/MrVw4qDq-BVGCbf2MpksJg/6S0qgFLXAdR7sOmr4ZpJN8TMT2RO9Hv1xTkeCA_2W3himOvQxW8NapMy8nXUPlN9xhxgqyPGHDhxt1WhksBsRR9nKIarG0KUrtOnehqVgUMVK5rg_RpgT28otag0hlqnMov8FGUjUS3cPWscpACHmQ/0xhr3erX07FzFQ9YJaEeM-34vIfeuzlaL7vzClWx9FE\: 404 - Not Found`
## Tickets
<!--- Paste Asana/Linear tickets here --->
https://linear.app/tezos/issue/ETH-141/scrape-images-from-airtable
## Notes for reviewer (optional)
<!--- 
- (For example): I wasn't sure whether to implement a caching strategy [here](https://…), so I left a comment and suggest that this is handled in a separate [ticket](https://…)
--->
